### PR TITLE
Torna a opção Área do Proprietário invisivel para inquilinos

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -12,7 +12,7 @@
             <% if current_user.user_type == 'tenant' %>
                 <h2>Quadro de Chamadas de Manutenção <h2>
                 <p class="dash-paragrafo">Para Criar, Editar e Excluir chamadas de manutenção clique no link a seguir.</p>
-                <p><%= link_to 'Quadro de manutenção', maintenances_path %></p>
+                <p><%= link_to 'Quadro de manutenção', maintenances_path, class: "btn btn-primary btn-tasks" %></p>
             <% end %>
            
             <% if current_user.user_type == 'proprietary' %>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -40,6 +40,9 @@
                 <ul class="container-fluid">
                     <li><%= link_to '  Dashboard', homepage_path, class: "icon-home" %></li>
                     <li><%= link_to '  Quadro de Tarefas', tasks_path, class: "icon-calendar" %></li>
+                    <% if current_user.user_type == 'tenant' %>
+                    <li><%= link_to '  Quadro de manutenção', maintenances_path, class: "icon-briefcase" %></li> 
+                     <% end %>
                      <% if current_user.user_type == 'proprietary' %>
                     <li><%= link_to '  Área do Proprietário', proprietary_path, class: "icon-briefcase" %></li> 
                      <% end %>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -40,7 +40,9 @@
                 <ul class="container-fluid">
                     <li><%= link_to '  Dashboard', homepage_path, class: "icon-home" %></li>
                     <li><%= link_to '  Quadro de Tarefas', tasks_path, class: "icon-calendar" %></li>
+                     <% if current_user.user_type == 'proprietary' %>
                     <li><%= link_to '  Área do Proprietário', proprietary_path, class: "icon-briefcase" %></li> 
+                     <% end %>
                 </ul>
         </div>
         


### PR DESCRIPTION
Retira a visibilidade da opção Área do Proprietário no dashboard  por parte dos inquilinos.